### PR TITLE
Correct translation of Chinese

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ The following languages are supported:
 - Turkish / Türkçe 🇹🇷
 - Ukrainian / Український 🇺🇦
 - Russian / Русский 🇷🇺
-- Chinese / 中国人 🇨🇳
+- Chinese / 中文 🇨🇳
 
 # Final notes
 


### PR DESCRIPTION
The English word Chinese refers both Chinese people and language but 中国人 only refers Chinese people. 中文 will be used for the language. (Comments from any native speakers are welcome:)